### PR TITLE
support for :grace_period a la LiveReload

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -39,7 +39,7 @@ Please read {Guard doc}[http://github.com/guard/guard#readme] for more info abou
 
 == Options
 
-LiveReload guard have 5 options that you can set like this:
+LiveReload guard has 6 options that you can set like this:
 
     guard 'livereload', :api_version => '1.4', :port => '35728' do
       ...
@@ -52,6 +52,7 @@ Available options:
     :port => '12345'         # default '35729'
     :apply_js_live => false  # default true
     :apply_css_live => false # default true
+    :grace_period => 0.5     # default 0 (seconds)
 
 See {LiveReload configuration doc}[http://github.com/mockko/livereload#readme] for more info about those options.
 

--- a/lib/guard/livereload.rb
+++ b/lib/guard/livereload.rb
@@ -19,7 +19,8 @@ module Guard
         :host => '0.0.0.0',
         :port => '35729',
         :apply_js_live => true,
-        :apply_css_live => true
+        :apply_css_live => true,
+        :grace_period => 0
       }.update(options)
     end
 
@@ -32,6 +33,7 @@ module Guard
     end
 
     def run_on_change(paths)
+      sleep @options[:grace_period]
       reactor.reload_browser(paths)
     end
 

--- a/spec/guard/livereload/reactor_spec.rb
+++ b/spec/guard/livereload/reactor_spec.rb
@@ -33,5 +33,5 @@ describe Guard::LiveReload::Reactor do
 end
 
 def new_live_reactor(options = {})
-  Guard::LiveReload::Reactor.new({ :api_version => '1.6', :host => '0.0.0.0', :port => '35729', :apply_js_live => true, :apply_css_live => true }.merge(options))
+  Guard::LiveReload::Reactor.new({ :api_version => '1.6', :host => '0.0.0.0', :port => '35729', :apply_js_live => true, :apply_css_live => true, :grace_period => 0 }.merge(options))
 end


### PR DESCRIPTION
I noticed about 1 in 5 times the browser reloads too fast for node.js to restart, so I've added support for passing a delay to guard-livereload.  In [mockko/livereload](https://github.com/mockko/livereload) it's called "grace_period", so I used that here.

It's got tests and I updated the readme.  Let me know if I've missed anything.

Cheers,
Tim
