### PR TITLE
Relax dependency on multi_json. 

### DIFF
--- a/guard-livereload.gemspec
+++ b/guard-livereload.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'guard',        '>= 0.10.0'
   s.add_dependency 'em-websocket', '>= 0.2.0'
-  s.add_dependency 'multi_json',   '~> 1.0.3'
+  s.add_dependency 'multi_json',   '~> 1.0'
 
   s.add_development_dependency 'bundler',     '~> 1.0'
   s.add_development_dependency 'rspec',       '~> 2.5'


### PR DESCRIPTION
The uglifier gem requires mutli_json 1.1.0, which is forcing
guard-livereload to be downgraded to version 0.2 when installed
via Bundler.

The specs pass.
