### PR TITLE
Update Guardfile templates

### DIFF
--- a/lib/guard/livereload/templates/Guardfile
+++ b/lib/guard/livereload/templates/Guardfile
@@ -1,5 +1,5 @@
 guard 'livereload' do
-  watch(%r{app/views/.+\.(erb|haml|slim)})
+  watch(%r{app/views/.+\.(erb|haml|slim)$})
   watch(%r{app/helpers/.+\.rb})
   watch(%r{public/.+\.(css|js|html)})
   watch(%r{config/locales/.+\.yml})


### PR DESCRIPTION
i modified the regex in the templates to make sure that erb, haml, and slim extension is at the end of string.
