### PR TITLE
Don't display v7 HELLO as Browser URL

### DIFF
--- a/lib/guard/livereload/reactor.rb
+++ b/lib/guard/livereload/reactor.rb
@@ -55,7 +55,7 @@ module Guard
               end
 
               ws.onmessage do |msg|
-                UI.info "Browser URL: #{msg}"
+                UI.info "Browser URL: #{msg}"  if msg =~ /^(https?|file):/
               end
 
               ws.onclose do


### PR DESCRIPTION
Hey!

I'm preparing to update all browser extensions; here's a cosmetic fix to make it go smoother. (I know I have commit access to the repo, but I thought I'd send a pull request since I've never contributed before.)

“Extensions 2.x send a JSON-encoded HELLO command to all new connections, which used to be displayed as a Browser URL.

To avoid user confusion, let's only display realistically-looking URLs.”
