### PR TITLE
Use EM.epoll to avoid file limit errors

### DIFF
--- a/lib/guard/livereload/reactor.rb
+++ b/lib/guard/livereload/reactor.rb
@@ -35,6 +35,7 @@ module Guard
 
       def start_threaded_reactor(options)
         Thread.new do
+          EventMachine.epoll
           EventMachine.run do
             UI.info "LiveReload is waiting for a browser to connect."
             EventMachine.start_server(options[:host], 35729, WebSocket, {}) do |ws|


### PR DESCRIPTION
Hi, on a current project I am getting these:

```
*** buffer overflow detected ***: ruby terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x37)[0x7fd7de40d007]
/lib/x86_64-linux-gnu/libc.so.6(+0x107f00)[0x7fd7de40bf00]
/lib/x86_64-linux-gnu/libc.so.6(+0x108fbe)[0x7fd7de40cfbe]
/usr/local/rvm/gems/ruby-1.9.3-p194/gems/eventmachine-0.12.10/lib/rubyeventmachine.so(_ZN14EventMachine_t14_RunSelectOnceEv+0xac)[0x7fd7dcec33dc]
/usr/local/rvm/gems/ruby-1.9.3-p194/gems/eventmachine-0.12.10/lib/rubyeventmachine.so(_ZN14EventMachine_t3RunEv+0x5c)[0x7fd7dcec61ec]
/usr/local/rvm/gems/ruby-1.9.3-p194/gems/eventmachine-0.12.10/lib/rubyeventmachine.so(+0x1e419)[0x7fd7dceca419]
```

with MRI 1.9.3. Adding an EM.epoll before starting the reactor avoids this. See http://stackoverflow.com/questions/12284520/em-websocket-buffer-overflow-detected-ruby-terminated
