### PR TITLE
Guard init template watches for images

### DIFF
--- a/lib/guard/livereload/templates/Guardfile
+++ b/lib/guard/livereload/templates/Guardfile
@@ -4,5 +4,5 @@ guard 'livereload' do
   watch(%r{public/.+\.(css|js|html)})
   watch(%r{config/locales/.+\.yml})
   # Rails Assets Pipeline
-  watch(%r{(app|vendor)(/assets/\w+/(.+\.(css|js|html))).*}) { |m| "/assets/#{m[3]}" }
+  watch(%r{(app|vendor)(/assets/\w+/(.+\.(css|js|html|png|jpg))).*}) { |m| "/assets/#{m[3]}" }
 end


### PR DESCRIPTION
Hi! I think monitoring changes in images could be helpful, so I added .png and .jpg to guard init template file.
