### PR TITLE
Mime type for HTML files and support index.html

### DIFF
--- a/lib/guard/livereload/websocket.rb
+++ b/lib/guard/livereload/websocket.rb
@@ -12,6 +12,7 @@ module Guard
         parser << data
         # prepend with '.' to make request url usable as a file path
         request_path = '.' + URI.parse(parser.request_url).path
+        request_path += '/index.html' if File.directory? request_path
         if parser.http_method != 'GET' || parser.upgrade?
           super #pass the request to websocket
         elsif request_path == './livereload.js'
@@ -33,7 +34,8 @@ module Guard
       end
 
       def _content_type(path)
-        case File.extname(path)
+        case File.extname(path).downcase
+        when '.html', '.htm' then 'text/html'
         when '.css' then 'text/css'
         when '.js' then 'application/ecmascript'
         when '.gif' then 'image/gif'


### PR DESCRIPTION
I have read #93 and in general agree wholeheartedly with the Unix philosophy. Nevertheless, since it's just 2 lines, it would be great to also serve html files with the correct mime type, and handle index.html files.

Note that this means the browser has to be directed to, e.g., http://localhost:35729/foo/bar.html

At least for my personal use case that consists mostly of js and css development (without any ruby server technology), this makes it considerably easier to get started.
