### PR TITLE
Module definition change in guard 2.0

### DIFF
--- a/lib/guard/livereload/reactor.rb
+++ b/lib/guard/livereload/reactor.rb
@@ -1,7 +1,7 @@
 require 'multi_json'
 
 module Guard
-  class LiveReload
+  class LiveReload < Plugin
     class Reactor
       attr_reader :web_sockets, :thread, :options, :connections_count
 


### PR DESCRIPTION
Guard has changed its Plugin module, so in the future the Guard::Guard module will be fully deprecated.
Right now there is a very annoying deprecation message. With the title: "BIG DEPRECATION MESSAGE"

Have tested this locally, let me know if you need anymore help

https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#changes-in-guardguard
