### PR TITLE
liveCSS reading for scss/sass files

### DIFF
--- a/js/livereload.js
+++ b/js/livereload.js
@@ -490,7 +490,7 @@
            }
          }
          if (options.liveCSS) {
-           if (path.match(/\.css$/i)) {
+           if (path.match(/\.(sa|sc|c)ss$/i)) {
              if (this.reloadStylesheet(path)) {
                return;
              }


### PR DESCRIPTION
Sprockets is going to stop supporting .scss.css extensions. Which means no liveCSS support until .scss and .sass extensions are supported directly as I've proposed in this PR.

Deprecation: http://stackoverflow.com/questions/27537437/upgraded-to-scss-rails-gem-gives-deprecation-warning

Related to https://github.com/guard/guard-livereload/issues/126