### PR TITLE
Guardfile support for filename.scss

### DIFF
--- a/lib/guard/livereload/templates/Guardfile
+++ b/lib/guard/livereload/templates/Guardfile
@@ -5,4 +5,5 @@ guard 'livereload' do
   watch(%r{config/locales/.+\.yml})
   # Rails Assets Pipeline
   watch(%r{(app|vendor)(/assets/\w+/(.+\.(css|js|html|png|jpg))).*}) { |m| "/assets/#{m[3]}" }
+  watch(%r{(app|vendor)(/assets/\w+/(.+)\.(sass|scss))}) { |m| "/assets/#{m[3]}.css" }
 end


### PR DESCRIPTION
The latest version of sprockets (as bundled with Rails 4.2) dictates scss partials be named `_filename.scss` instead of `_filename.css.scss` as it was done previously. The current Guardfile regular expressions do not match this new naming pattern.

This PR modifies the default Guardfile so that changes to .scss files can be picked up by livereload.