### PR TITLE
Add Mac OS X kqueue support, silence epoll warning

### DIFF
--- a/lib/guard/livereload/reactor.rb
+++ b/lib/guard/livereload/reactor.rb
@@ -45,7 +45,8 @@ module Guard
       end
 
       def _start_reactor
-        EventMachine.epoll
+        EventMachine.epoll  if EventMachine.epoll?
+        EventMachine.kqueue if EventMachine.kqueue?
         EventMachine.run do
           EventMachine.start_server(options[:host], options[:port], WebSocket, {}) do |ws|
             ws.onopen    { _connect(ws) }


### PR DESCRIPTION
This enables epoll only if supported, to supress the warning
`warning: epoll is not supported on this platform` in eventmachine
1.0.8+ and enables [kqueue](https://en.wikipedia.org/wiki/Kqueue) if supported (BSD/Darwin).