### PR TITLE
missing tmpfile workaround (#148)

### DIFF
--- a/lib/guard/livereload.rb
+++ b/lib/guard/livereload.rb
@@ -22,7 +22,10 @@ module Guard
       }.merge(options)
 
       js_path = @options[:js_template]
-      @options[:livereload_js_path] = Snippet.new(js_path, @options).path
+
+      # NOTE: save snippet as instvar, so it's not GC'ed
+      @snippet = Snippet.new(js_path, @options)
+      @options[:livereload_js_path] = @snippet.path
     end
 
     def start

--- a/lib/guard/livereload/snippet.rb
+++ b/lib/guard/livereload/snippet.rb
@@ -11,12 +11,14 @@ module Guard
 
       def initialize(template, options)
         @options = options # for ERB context
-        tmpfile = Tempfile.new('livereload.js')
+
+        # NOTE: use instance variable for Tempfile, so it's not GC'ed before sending
+        @tmpfile = Tempfile.new('livereload.js')
         source = IO.read(template)
         data = ERB.new(source).result(binding)
-        tmpfile.write(data)
-        tmpfile.close
-        @path = tmpfile.path
+        @tmpfile.write(data)
+        @tmpfile.close
+        @path = @tmpfile.path
       end
     end
   end


### PR DESCRIPTION
Prevent Tempfile instance from being GC'ed (which deletes the file before it's uploaded).