### PR TITLE
Switch JRuby versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 bundler_args: --without development
 rvm:
   - 2.2.3
-  - jruby-19mode
+  - jruby-head
 matrix:
   allow_failures:
-    - rvm: jruby-19mode
+    - rvm: jruby-head
 notifications:
   recipients:
     - thibaud@thibaud.me


### PR DESCRIPTION
Use JRuby head - due to constant improvements making JRuby better