### PR TITLE
ignore exceptions on Websocket dispatch parsing

### DIFF
--- a/lib/guard/livereload/websocket.rb
+++ b/lib/guard/livereload/websocket.rb
@@ -22,6 +22,8 @@ module Guard
         else
           _serve(request_path)
         end
+      rescue
+        # ignored
       end
 
       private


### PR DESCRIPTION
For me this kept crasching in the HTTP::parser.
This hack makes this module usable for me.