### PR TITLE
Update gem version in readme to reflect #159

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add it to your Gemfile (inside development group):
 
 ``` ruby
 group :development do
-  gem 'guard-livereload', '~> 2.4', require: false
+  gem 'guard-livereload', '~> 2.5', require: false
 end
 ```
 


### PR DESCRIPTION
It is advised in #159 to upgrade to `2.5.2`, but readme still states to use `2.4`