### PR TITLE
Enforce js extension on erb tmp file

### DIFF
--- a/lib/guard/livereload/snippet.rb
+++ b/lib/guard/livereload/snippet.rb
@@ -13,7 +13,7 @@ module Guard
         @options = options # for ERB context
 
         # NOTE: use instance variable for Tempfile, so it's not GC'ed before sending
-        @tmpfile = Tempfile.new('livereload.js')
+        @tmpfile = Tempfile.new(['livereload', '.js'])
         source = IO.read(template)
         data = ERB.new(source).result(binding)
         @tmpfile.write(data)


### PR DESCRIPTION
After receiving a browser warning, that `livereload.js` is served with a wring mime type (text/plain) I encountered, that the `tempfile` being served doesn't end with `js` and thus isn't detected correctly.
This fix ensures a tmpfile extension of `.js` and the mime type being delivered correctly.

No adaption to the tests because this particular part isn't tested (no integration test available) and everything is stubbed out.
IMO there should be a test for the correct extension because this is essential for the functionality outside of the module, but this may contradict to the initial author's intention for stubbing out any use of external classes.

Let me know what you think and if you want to change this behavior.