### PR TITLE
[tiny] README - rephrase warning for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#### :warning: :warning: :warning: Security Vulnerability: please upgrade to v2.5.2 - [details here ](https://github.com/guard/guard-livereload/issues/159). (Credits: [Michael Coyne](https://github.com/mikeycgto))
+#### :warning: :warning: :warning: Security: **please upgrade to v2.5.2** — there is a security vulnerability for versions `<2.5.2`. [Details here ](https://github.com/guard/guard-livereload/issues/159). (Credits: [Michael Coyne](https://github.com/mikeycgto))
 
 # Guard::LiveReload
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#### :warning: :warning: :warning: Security: **please upgrade to v2.5.2** — there is a security vulnerability for versions `<2.5.2`. [Details here ](https://github.com/guard/guard-livereload/issues/159). (Credits: [Michael Coyne](https://github.com/mikeycgto))
+#### :warning: :warning: :warning: Security: **Please upgrade to v2.5.2** — there is a security vulnerability for versions `<2.5.2`. [Details here](https://github.com/guard/guard-livereload/issues/159). (Credits: [Michael Coyne](https://github.com/mikeycgto))
 
 # Guard::LiveReload
 


### PR DESCRIPTION
Please forgive me for over-explaining a tiny/trivial change 😅  

On first glance it looks like this is still vulnerable — or so I thought. I think this slight rephrase makes it more clear on first glance. 

Given this is a development tool, I think catering to "at first glance" makes sense, since in development we're thinking "just go go go!" 

(Versus in production mindset when we make more measured choices; for me that means reading a README more slowly for production, versus jumping around more in dev mindset.)