### PR TITLE
Fix detection of IPv6 literal hostnames (with colons)

### DIFF
--- a/js/livereload.js.erb
+++ b/js/livereload.js.erb
@@ -345,7 +345,7 @@
        element = _ref[_i];
        if ((src = element.src) && (m = src.match(/^[^:]+:\/\/(.*)\/z?livereload\.js(?:\?(.*))?$/))) {
          options = new Options();
-         if (mm = m[1].match(/^([^\/:]+)(?::(\d+))?$/)) {
+         if (mm = m[1].match(/^([^\/]+?)(?::(\d+))?$/)) {
            options.host = mm[1];
            if (mm[2]) {
              options.port = parseInt(mm[2], 10);


### PR DESCRIPTION
Hostnames in URIs can be of the form https://[::1]:4711/foo
This is currently read as "[", which is not a valid hostname.
